### PR TITLE
Add the "Descend" Command to the Help

### DIFF
--- a/src/curses/ui.rs
+++ b/src/curses/ui.rs
@@ -1519,6 +1519,7 @@ impl Ui {
         nc::waddstr(window, "Strafe/attack: Shift + h/l\n");
         nc::waddstr(window, "Charge: c\n");
         nc::waddstr(window, "Wait: .\n");
+        nc::waddstr(window, "Descend: >\n");
         nc::waddstr(window, "Autoexplore: o\n");
         nc::waddstr(window, "Automove: shift + k\n");
         nc::waddstr(window, "Go to: G (only '>' follow-up implemented)\n");


### PR DESCRIPTION
For some reason this was missing, so it took me quite some time to figure out how to use the stairs. So this definitely should be added to the help menu.
