### PR TITLE
Add "[ESC] to close" to the Inventory Menu

### DIFF
--- a/src/curses/ui.rs
+++ b/src/curses/ui.rs
@@ -1230,8 +1230,9 @@ impl Ui {
             for (ch, i) in &player.items_backpack {
                 nc::waddstr(window, &format!(" {} - {}\n", ch, i.description()));
             }
-            nc::waddstr(window, &format!("\n"));
         }
+
+        nc::waddstr(window, &format!("\n[ESC] to close...\n"));
 
         nc::wnoutrefresh(window);
     }


### PR DESCRIPTION
Turns out it's not that obvious how to get out of the Inventory again (#10). 
